### PR TITLE
Add ability to specify custom policy name

### DIFF
--- a/apis/minio/v1/policy_types.go
+++ b/apis/minio/v1/policy_types.go
@@ -47,6 +47,10 @@ type PolicyProviderStatus struct {
 }
 
 type PolicyParameters struct {
+	// The name of the policy
+	// Defaults to `metadata.name` if unset.
+	Name string `json:"name,omitempty"`
+
 	// AllowBucket will create a simple policy that allows all operations for the given bucket.
 	// Mutually exclusive to `RawPolicy`.
 	AllowBucket string `json:"allowBucket,omitempty"`
@@ -72,3 +76,11 @@ var (
 	PolicyKindAPIVersion   = PolicyKind + "." + SchemeGroupVersion.String()
 	PolicyGroupVersionKind = SchemeGroupVersion.WithKind(PolicyKind)
 )
+
+// GetPolicyName returns the spec.forProvider.name if given, otherwise defaults to metadata.name.
+func (in *Policy) GetPolicyName() string {
+	if in.Spec.ForProvider.Name == "" {
+		return in.Name
+	}
+	return in.Spec.ForProvider.Name
+}

--- a/operator/policy/create.go
+++ b/operator/policy/create.go
@@ -37,7 +37,7 @@ func (p *policyClient) Create(ctx context.Context, mg resource.Managed) (managed
 		return managed.ExternalCreation{}, err
 	}
 
-	if _, ok := policyies[policy.GetName()]; ok {
+	if _, ok := policyies[policy.GetPolicyName()]; ok {
 		return managed.ExternalCreation{}, fmt.Errorf("policy already exists")
 	}
 
@@ -58,7 +58,7 @@ func (p *policyClient) createBucketPolicy(ctx context.Context, policy *miniov1.P
 		return err
 	}
 
-	err = p.ma.AddCannedPolicy(ctx, policy.GetName(), parsedPolicy)
+	err = p.ma.AddCannedPolicy(ctx, policy.GetPolicyName(), parsedPolicy)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (p *policyClient) createBucketPolicy(ctx context.Context, policy *miniov1.P
 }
 
 func (p *policyClient) createRawPolicy(ctx context.Context, policy *miniov1.Policy) error {
-	err := p.ma.AddCannedPolicy(ctx, policy.GetName(), []byte(policy.Spec.ForProvider.RawPolicy))
+	err := p.ma.AddCannedPolicy(ctx, policy.GetPolicyName(), []byte(policy.Spec.ForProvider.RawPolicy))
 	if err != nil {
 		return err
 	}

--- a/operator/policy/delete.go
+++ b/operator/policy/delete.go
@@ -22,7 +22,7 @@ func (p *policyClient) Delete(ctx context.Context, mg resource.Managed) error {
 
 	policy.SetConditions(xpv1.Deleting())
 	p.emitDeletionEvent(policy)
-	return p.ma.RemoveCannedPolicy(ctx, policy.GetName())
+	return p.ma.RemoveCannedPolicy(ctx, policy.GetPolicyName())
 }
 
 func (p *policyClient) emitDeletionEvent(policy *miniov1.Policy) {

--- a/operator/policy/observer.go
+++ b/operator/policy/observer.go
@@ -33,7 +33,7 @@ func (p *policyClient) Observe(ctx context.Context, mg resource.Managed) (manage
 		return managed.ExternalObservation{}, err
 	}
 
-	observedPolicy, ok := policies[policy.GetName()]
+	observedPolicy, ok := policies[policy.GetPolicyName()]
 	if !ok {
 		// The policy hasn't yet been created it seems
 		return managed.ExternalObservation{ResourceExists: false}, nil

--- a/operator/policy/update.go
+++ b/operator/policy/update.go
@@ -26,7 +26,7 @@ func (p *policyClient) Update(ctx context.Context, mg resource.Managed) (managed
 		return managed.ExternalUpdate{}, err
 	}
 
-	_, ok = policies[policy.GetName()]
+	_, ok = policies[policy.GetPolicyName()]
 	if !ok {
 		return managed.ExternalUpdate{}, fmt.Errorf("policy does not exist")
 	}

--- a/package/crds/minio.crossplane.io_policies.yaml
+++ b/package/crds/minio.crossplane.io_policies.yaml
@@ -74,6 +74,11 @@ spec:
                       AllowBucket will create a simple policy that allows all operations for the given bucket.
                       Mutually exclusive to `RawPolicy`.
                     type: string
+                  name:
+                    description: |-
+                      The name of the policy
+                      Defaults to `metadata.name` if unset.
+                    type: string
                   rawPolicy:
                     description: |-
                       RawPolicy describes a raw S3 policy ad verbatim.


### PR DESCRIPTION
## Summary
 
Adds ability to specify custom policy name. It is required, if you need to use a policy name that breaks Kubernetes name validation of `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`. Faced this issues when a policy name needed to be with all capital letters with '_'.

In a way related to https://github.com/vshn/provider-minio/issues/59 as I am adding general tenant management improvements that I need in my workplace as we plan to use this provider.

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
