### PR TITLE
Build multi-arch xpkg packages (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,11 @@ jobs:
 
       - name: Push docker image
         if: env.PUSH_IMAGE == 'true'
-        run: make docker-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }}
+        run: make docker-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }} -e ORG=${{ github.repository_owner }}
 
       - name: Build and push function package
         if: env.PUSH_PACKAGE == 'true'
-        run: make package-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }}
+        run: make package-push -e IMG_TAG=${GITHUB_REF##*/} -e APP_NAME=${{ env.APP_NAME }} -e ORG=${{ github.repository_owner }}
 
       - name: Login to Upbound
         if: env.PUSH_UPBOUND == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,17 @@ on:
 
 env:
   APP_NAME: provider-minio
-  PUSH_UPBOUND: "True"
-  PUSH_PACKAGE: "True"
-  PUSH_IMAGE: "False"
+  PUSH_UPBOUND: "true"
+  PUSH_PACKAGE: "true"
+  PUSH_IMAGE: "false"
   SUFFIX: "/controller"
 
 jobs:
   dist:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # goreleaser needs this to publish GitHub releases
+      packages: write   # crank xpkg push and docker login need this for GHCR
     steps:
 
       - uses: actions/checkout@v4

--- a/ci.mk
+++ b/ci.mk
@@ -11,14 +11,28 @@ UPBOUND_CONTAINER_REGISTRY ?= xpkg.upbound.io
 UPBOUND_PACKAGE_IMG ?= $(UPBOUND_CONTAINER_REGISTRY)/$(ORG)/$(APP_NAME):$(IMG_TAG)
 
 # For alpine image it is required the following env before building the application
+# DOCKER_IMAGE_GOARCH is a space-separated list; one runtime image is built per
+# architecture and the package is pushed as a multi-arch index.
 DOCKER_IMAGE_GOOS = linux
-DOCKER_IMAGE_GOARCH = amd64
+DOCKER_IMAGE_GOARCH ?= amd64 arm64
+
+# Comma-join helper for crank's -f flag
+empty :=
+space := $(empty) $(empty)
+comma := ,
+XPKG_FILES = $(patsubst %,package/package-%.xpkg,$(DOCKER_IMAGE_GOARCH))
 
 .PHONY: docker-build
 docker-build:
-	env CGO_ENABLED=0 GOOS=$(DOCKER_IMAGE_GOOS) GOARCH=$(DOCKER_IMAGE_GOARCH) \
-		go build -o ${BIN_FILENAME}
-	docker build --platform $(DOCKER_IMAGE_GOOS)/$(DOCKER_IMAGE_GOARCH) -t ${IMG} .
+	@for arch in $(DOCKER_IMAGE_GOARCH); do \
+		env CGO_ENABLED=0 GOOS=$(DOCKER_IMAGE_GOOS) GOARCH=$$arch \
+			go build -o ${BIN_FILENAME} && \
+		$(DOCKER_CMD) build --platform $(DOCKER_IMAGE_GOOS)/$$arch -t ${IMG}-$$arch . \
+		|| exit 1; \
+	done
+	@# Keep the un-suffixed tag for single-image consumers (kind-load-image);
+	@# points at the first architecture in the list (amd64 by default).
+	$(DOCKER_CMD) tag ${IMG}-$(firstword $(DOCKER_IMAGE_GOARCH)) ${IMG}
 
 .PHONY: docker-build-branchtag
 docker-build-branchtag: export IMG_TAG=$(shell git rev-parse --abbrev-ref HEAD | sed 's/\//_/g')
@@ -35,11 +49,14 @@ docker-push-branchtag: docker-build-branchtag docker-push ## Push docker image w
 .PHONY: package-build
 package-build: docker-build
 	rm -f package/*.xpkg
-	go run github.com/crossplane/crossplane/cmd/crank@v1.16.0 xpkg build -f package --verbose --embed-runtime-image=${IMG} -o package/package.xpkg
+	@for arch in $(DOCKER_IMAGE_GOARCH); do \
+		go run github.com/crossplane/crossplane/cmd/crank@v1.16.0 xpkg build -f package --verbose --embed-runtime-image=${IMG}-$$arch -o package/package-$$arch.xpkg \
+		|| exit 1; \
+	done
 
 .PHONY: package-push
 package-push: package-build
-	go run github.com/crossplane/crossplane/cmd/crank@v1.16.0 xpkg push -f package/package.xpkg ${IMG} --verbose
+	go run github.com/crossplane/crossplane/cmd/crank@v1.16.0 xpkg push -f $(subst $(space),$(comma),$(XPKG_FILES)) ${IMG} --verbose
 
 .PHONY: package-build-branchtag
 package-build-branchtag: export IMG_TAG=$(shell git rev-parse --abbrev-ref HEAD | sed 's/\//_/g')

--- a/ci.mk
+++ b/ci.mk
@@ -40,7 +40,7 @@ docker-build-branchtag: docker-build ## Build docker image with current branch n
 
 .PHONY: docker-push
 docker-push: docker-build ## Push docker image with the manager.
-	docker push ${IMG}
+	$(DOCKER_CMD) push ${IMG}
 
 .PHONY: docker-push-branchtag
 docker-push-branchtag: export IMG_TAG=$(shell git rev-parse --abbrev-ref HEAD | sed 's/\//_/g')


### PR DESCRIPTION
## Problem

The published provider package embeds an amd64-only runtime image. On arm64 clusters (e.g. Apple Silicon dev machines running kind, or AWS Graviton nodes) the provider pod crashes immediately because the embedded binary is the wrong architecture.

## Solution

Build one runtime image per architecture and push the `.xpkg` files together as a multi-arch OCI index using crank's multi-file `-f` flag. Crossplane will then pull the correct image for each node's architecture.

### Changes

**`ci.mk`**
- `DOCKER_IMAGE_GOARCH` becomes a space-separated list (`amd64 arm64` by default, overridable)
- `docker-build` loops over each arch, producing `${IMG}-amd64` / `${IMG}-arm64` images; keeps an un-suffixed `${IMG}` alias pointing at the first arch for local consumers (`kind-load-image`, etc.)
- `package-build` loops over each arch, producing `package/package-amd64.xpkg` and `package/package-arm64.xpkg`
- `package-push` passes all `.xpkg` files as a comma-joined `-f` list so crank pushes a single multi-arch manifest
- `docker-push` now uses `$(DOCKER_CMD)` for consistency with `docker-build`
- Pass `ORG=${{ github.repository_owner }}` in the release workflow so the image registry path resolves correctly when run from any fork

**`.github/workflows/release.yml`**
- Lowercase `PUSH_UPBOUND`/`PUSH_PACKAGE`/`PUSH_IMAGE` env values — GitHub Actions comparisons are case-sensitive, so `"True" != 'true'` was silently skipping the package-push step on every release
- Add explicit `permissions: contents: write, packages: write` to the dist job so `GITHUB_TOKEN` can publish GitHub releases and push to GHCR

## Testing

Verified locally: `make package-build` produces both `package/package-amd64.xpkg` and `package/package-arm64.xpkg`, and `make package-push` combines them into a single multi-arch OCI index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)